### PR TITLE
Task adjust admin page

### DIFF
--- a/app/Http/Controllers/Admin/BrandController.php
+++ b/app/Http/Controllers/Admin/BrandController.php
@@ -28,7 +28,7 @@ class BrandController extends Controller
         $data = $request->validated();
         $brand = new Brand();
         $brand->name = $data['name'];
-        $brand->navbar_status = $request->navbar_status == true ? '1':'0';
+        $brand->navbar_status = '0';
         $brand->status = $request->status == true ? '1':'0';
         $brand->created_by = Auth::user()->id;
         $brand->save();
@@ -46,7 +46,7 @@ class BrandController extends Controller
         $data = $request->validated();
         $brand = Brand::find($brand_id);
         $brand->name = $data['name'];
-        $brand->navbar_status = $request->navbar_status == true ? '1':'0';
+        $brand->navbar_status = '0';
         $brand->status = $request->status == true ? '1':'0';
         $brand->created_by = Auth::user()->id;
         $brand->update();

--- a/app/Http/Controllers/Admin/BrandController.php
+++ b/app/Http/Controllers/Admin/BrandController.php
@@ -14,7 +14,8 @@ class BrandController extends Controller
     public function index()
     {
         $brand = Brand::all();
-        return view('admin.brand.index', compact('brand')); 
+        $orderCount = 1;
+        return view('admin.brand.index', compact('brand', 'orderCount')); 
     }
 
     public function create()

--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -15,7 +15,8 @@ class CategoryController extends Controller
     public function index()
     {
         $category = Category::all();
-        return view('admin.category.index', compact('category'));
+        $orderCount = 1;
+        return view('admin.category.index', compact('category', 'orderCount'));
     }
 
     public function create()

--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -32,7 +32,7 @@ class CategoryController extends Controller
         $category->name = $data['name'];
         $category->slug = $data['slug'];
         $category->parent_id = $data['parent_category'];
-        $category->navbar_status = $request->navbar_status == true ? '1':'0';
+        $category->navbar_status = '0';
         $category->status = $request->status == true ? '1':'0';
         $category->created_by = Auth::user()->id;
         {
@@ -69,7 +69,7 @@ class CategoryController extends Controller
         $category->name = $data['name'];
         $category->slug = $data['slug'];
         $category->parent_id = $data['parent_category'];
-        $category->navbar_status = $request->navbar_status == true ? '1':'0';
+        $category->navbar_status = '0';
         $category->status = $request->status == true ? '1':'0';
         $category->created_by = Auth::user()->id;
         if($request->hasFile('thumbnail'))

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -20,7 +20,7 @@ class DashboardController extends Controller
         $categoriesTotal = Category::count();
         $brandsTotal = Brand::count();
         $allUsersTotal = User::count();
-        $adminsTotal = User::where('user_type', '1')->count();
+        $adminsTotal = User::where('user_type', '!=', '0')->count();
         $usersTotal = User::where('user_type', '0')->count();
 
         $thisMonth = Carbon::now()->format('m');

--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -20,8 +20,9 @@ class ProductController extends Controller
     public function index()
     {
         //
+        $orderCount = 1;
         $product = Product::all();
-        return view('admin.product.index', compact('product'));
+        return view('admin.product.index', compact('product', 'orderCount'));
     }
 
     /**

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -15,7 +15,7 @@ class UserController extends Controller
     public function index()
     {
         //
-        $user = User::where('id', '!=', Auth::user()->id)->get();;
+        $user = User::where('user_type', '!=', '2')->where('id', '!=', Auth::user()->id)->get();
         return view('admin.user.index', compact('user'));
     }
 

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -15,8 +15,9 @@ class UserController extends Controller
     public function index()
     {
         //
+        $orderCount = 1;
         $user = User::where('user_type', '!=', '2')->where('id', '!=', Auth::user()->id)->get();
-        return view('admin.user.index', compact('user'));
+        return view('admin.user.index', compact('user', 'orderCount'));
     }
 
      /**

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -32,7 +32,7 @@ class LoginController extends Controller
 
     public function authenticated()
     {
-        if(Auth::user()->user_type == '1') // 1 == Admin
+        if(Auth::user()->user_type == '1' || Auth::user()->user_type == '2') // 1 == Admin; 2 == Elder Admin
         {
             return redirect('/admin/dashboard')->with('status', 'Đăng nhập trang Admin thành công.');
         }

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -18,7 +18,7 @@ class AdminMiddleware
     {
         if(Auth::check())
         {
-            if(Auth::user()->user_type == 1)
+            if(Auth::user()->user_type == 1 || Auth::user()->user_type == '2')
             {
                 return $next($request);
             }

--- a/resources/views/admin/brand/create.blade.php
+++ b/resources/views/admin/brand/create.blade.php
@@ -27,10 +27,10 @@
                 
                 <h6>Đặt trạng thái</h6>
                 <div class="row">
-                    <div class="col-md-3 mb-3">
+                    {{-- <div class="col-md-3 mb-3">
                         <label for="navbar_status">Thanh điều hướng</label>
                         <input type="checkbox" name="navbar_status">
-                    </div>
+                    </div> --}}
                     <div class="col-md-3 mb-3">
                         <label for="status">Ẩn</label>
                         <input type="checkbox" name="status">

--- a/resources/views/admin/brand/edit.blade.php
+++ b/resources/views/admin/brand/edit.blade.php
@@ -28,10 +28,10 @@
                 
                 <h6>Đặt trạng thái</h6>
                 <div class="row">
-                    <div class="col-md-3 mb-3">
+                    {{-- <div class="col-md-3 mb-3">
                         <label for="navbar_status" class="h6">Thanh điều hướng</label>
                         <input type="checkbox" name="navbar_status" {{ $brand->navbar_status == 1 ? 'checked':'' }}>
-                    </div>
+                    </div> --}}
                     <div class="col-md-3 mb-3">
                         <label for="status">Ẩn</label>
                         <input type="checkbox" name="status" {{ $brand->status == 1 ? 'checked':'' }}>

--- a/resources/views/admin/brand/index.blade.php
+++ b/resources/views/admin/brand/index.blade.php
@@ -34,7 +34,7 @@
                 <tbody>
                     @foreach ($brand as $branditem)
                         <tr>
-                            <td>{{ $branditem->id }}</td>
+                            <td>{{ $orderCount++ }}</td>
                             <td>{{ $branditem->name }}</td>
                             <td>{{ $branditem->status == '1' ? 'Ẩn':'Hiện' }}</td>
                             {{--                             

--- a/resources/views/admin/category/create.blade.php
+++ b/resources/views/admin/category/create.blade.php
@@ -30,7 +30,7 @@
                     <input type="text" name="slug" class="form-control" autocomplete="off">
                 </div>
                 
-                <div class="mb-3">
+                {{-- <div class="mb-3">
                     <label for="parent_category" class="h6">Danh mục chính</label>
                     <select name="parent_category" id="parent_category" class="form-select">
                         <option value="">Là danh mục chính</option>
@@ -40,7 +40,7 @@
                             @endif
                         @endforeach
                     </select>
-                </div>
+                </div> --}}
 
                 <div class="mb-3">
                     <label for="thumbnail" class="h6">Ảnh đại diện (Chọn một ảnh)</label>
@@ -49,10 +49,10 @@
                 
                 <h6>Đặt trạng thái</h6>
                 <div class="row">
-                    <div class="col-md-3 mb-3">
+                    {{-- <div class="col-md-3 mb-3">
                         <label for="navbar_status">Thanh điều hướng</label>
                         <input type="checkbox" name="navbar_status">
-                    </div>
+                    </div> --}}
                     <div class="col-md-3 mb-3">
                         <label for="status">Ẩn</label>
                         <input type="checkbox" name="status">

--- a/resources/views/admin/category/edit.blade.php
+++ b/resources/views/admin/category/edit.blade.php
@@ -31,7 +31,7 @@
                     <input type="text" name="slug" value="{{ $category->slug }}" class="form-control" autocomplete="off">
                 </div>
 
-                <div class="mb-3">
+                {{-- <div class="mb-3">
                     <label for="parent_category" class="h6">Danh mục chính</label>
                     <select name="parent_category" id="parent_category" class="form-select">
                         <option value="">Là danh mục chính</option>
@@ -41,7 +41,7 @@
                             @endif
                         @endforeach
                     </select>
-                </div>
+                </div> --}}
 
                 <div class="mb-3">
                     <label for="thumbnail" class="h6">Ảnh đại diện (Chọn một ảnh)</label>
@@ -50,10 +50,10 @@
                 
                 <h6>Đặt trạng thái</h6>
                 <div class="row">
-                    <div class="col-md-3 mb-3">
+                    {{-- <div class="col-md-3 mb-3">
                         <label for="navbar_status">Thanh điều hướng</label>
                         <input type="checkbox" name="navbar_status" {{ $category->navbar_status == 1 ? 'checked':'' }}>
-                    </div>
+                    </div> --}}
                     <div class="col-md-3 mb-3">
                         <label for="status">Ẩn</label>
                         <input type="checkbox" name="status" {{ $category->status == 1 ? 'checked':'' }}>

--- a/resources/views/admin/category/index.blade.php
+++ b/resources/views/admin/category/index.blade.php
@@ -28,36 +28,36 @@
                         <th>Tên danh mục</th>
                         <th>Slug</th>
                         <th>Ảnh đại diện</th>
-                        <th>Danh mục chính</th>
+                        {{-- <th>Danh mục chính</th> --}}
                         <th>Trạng thái</th>
-                        <th class="w-25">Tác vụ</th>
+                        <th>Tác vụ</th>
                     </tr>
                 </thead>
 
                 <tbody>
                     @foreach ($category as $cateitem)
                         <tr>
-                            <td>{{ $cateitem->id }}</td>
+                            <td>{{ $orderCount++ }}</td>
                             <td>{{ $cateitem->name }}</td>
                             <td>{{ $cateitem->slug }}</td>
                             <td> 
                                 <img src="{{ asset('images/categories/' . $cateitem->thumbnail) }}" width="70px" height="70px" alt="Thumbnail">
                             </td>
-                            <td>
+                            {{-- <td>
                                 @if ($cateitem->parent_id == '')
                                     Là danh mục chính
                                 @else
                                     {{ $cateitem->parent->name }}
                                 @endif
-                            </td>
+                            </td> --}}
                             <td>{{ $cateitem->status == '1' ? 'Ẩn':'Hiện' }}</td>
                             <td>
                                 <div class="row">
-                                    <div class="col-md-3">
+                                    {{-- <div class="col-md-3">
                                         <a href="#" class="btn btn-sm btn-info" data-bs-toggle="tooltip" data-bs-placement="right" title="Chi tiết">
                                             <i class="bi bi-info-circle"></i>
                                         </a>
-                                    </div>
+                                    </div> --}}
 
                                     <div class="col-md-3">
                                         <a href="{{ url('admin/categories/'.$cateitem->id.'/edit') }}" class="btn btn-sm btn-success" data-bs-toggle="tooltip" data-bs-placement="right" title="Sửa">

--- a/resources/views/admin/order/edit.blade.php
+++ b/resources/views/admin/order/edit.blade.php
@@ -60,9 +60,9 @@
                                     <img src="{{ asset('images/products/thumbnail/' . $orderitem->product->thumbnail) }}" style="width: 70px; height: 70px" alt="">
                                 </td>
                                 <td>{{ $orderitem->product->name }}</td>
-                                <td>{{ $orderitem->price }} VNĐ</td>
+                                <td>{{ number_format($orderitem->price, 0, ".", ".") }} đ</td>
                                 <td>{{ $orderitem->quantity }}</td>
-                                <td class="fw-bold">{{ $orderitem->quantity * $orderitem->price }} VNĐ</td>
+                                <td class="fw-bold">{{ number_format($orderitem->quantity * $orderitem->price, 0, ".", ".") }} đ</td>
                                 @php
                                     $totalPrice += $orderitem->price * $orderitem->quantity;
                                 @endphp
@@ -70,7 +70,7 @@
                             @endforeach
                             <tr>
                                 <td colspan="5" class="fw-bold">Tổng tiền đơn hàng:</td>
-                                <td colspan="1" class="fw-bold">{{ $totalPrice }} VNĐ</td>
+                                <td colspan="1" class="fw-bold">{{ number_format($totalPrice, 0, ".", ".") }} đ</td>
                             </tr>
                         </tbody>
                     </table>

--- a/resources/views/admin/order/show.blade.php
+++ b/resources/views/admin/order/show.blade.php
@@ -69,9 +69,9 @@
                                     <img src="{{ asset('images/products/thumbnail/' . $orderitem->product->thumbnail) }}" style="width: 70px; height: 70px" alt="">
                                 </td>
                                 <td>{{ $orderitem->product->name }}</td>
-                                <td>{{ number_format($orderitem->price, 0, ".", ".") }} đ</td>
+                                <td>{{ number_format($orderitem->price, 0, ",", ".") }} đ</td>
                                 <td>{{ $orderitem->quantity }}</td>
-                                <td class="fw-bold">{{ number_format($orderitem->quantity * $orderitem->price, 0, ".", ".") }} đ</td>
+                                <td class="fw-bold">{{ number_format($orderitem->quantity * $orderitem->price, 0, ",", ".") }} đ</td>
                                 @php
                                     $totalPrice += $orderitem->price * $orderitem->quantity;
                                 @endphp
@@ -79,7 +79,7 @@
                             @endforeach
                             <tr>
                                 <td colspan="5" class="fw-bold">Tổng tiền đơn hàng:</td>
-                                <td colspan="1" class="fw-bold">{{ number_format($totalPrice, 0, ".", ".") }} đ</td>
+                                <td colspan="1" class="fw-bold">{{ number_format($totalPrice, 0, ",", ".") }} đ</td>
                             </tr>
                         </tbody>
                     </table>

--- a/resources/views/admin/order/show.blade.php
+++ b/resources/views/admin/order/show.blade.php
@@ -69,9 +69,9 @@
                                     <img src="{{ asset('images/products/thumbnail/' . $orderitem->product->thumbnail) }}" style="width: 70px; height: 70px" alt="">
                                 </td>
                                 <td>{{ $orderitem->product->name }}</td>
-                                <td>{{ $orderitem->price }} VNĐ</td>
+                                <td>{{ number_format($orderitem->price, 0, ".", ".") }} đ</td>
                                 <td>{{ $orderitem->quantity }}</td>
-                                <td class="fw-bold">{{ $orderitem->quantity * $orderitem->price }} VNĐ</td>
+                                <td class="fw-bold">{{ number_format($orderitem->quantity * $orderitem->price, 0, ".", ".") }} đ</td>
                                 @php
                                     $totalPrice += $orderitem->price * $orderitem->quantity;
                                 @endphp
@@ -79,7 +79,7 @@
                             @endforeach
                             <tr>
                                 <td colspan="5" class="fw-bold">Tổng tiền đơn hàng:</td>
-                                <td colspan="1" class="fw-bold">{{ $totalPrice }} VNĐ</td>
+                                <td colspan="1" class="fw-bold">{{ number_format($totalPrice, 0, ".", ".") }} đ</td>
                             </tr>
                         </tbody>
                     </table>

--- a/resources/views/admin/product/create.blade.php
+++ b/resources/views/admin/product/create.blade.php
@@ -75,7 +75,7 @@
                     <input type="file" required name="images[]" multiple class="form-control">
                 </div>
 
-                <div class="mb-3">
+                {{-- <div class="mb-3">
                     <label for="discounts" class="h6">Chương trình khuyến mại</label>
                     <select name="discount" id="discount" class="form-select">
                         <option value="">Không có</option>
@@ -83,7 +83,7 @@
                             <option value="{{ $disitem->id }}">{{ $disitem->name }}</option>
                         @endforeach
                     </select>
-                </div>
+                </div> --}}
 
                 <h6>Đặt trạng thái</h6>
                 <div class="row">

--- a/resources/views/admin/product/edit.blade.php
+++ b/resources/views/admin/product/edit.blade.php
@@ -78,7 +78,7 @@
                     <input type="file" name="images[]" multiple class="form-control">
                 </div>
 
-                <div class="mb-3">
+                {{-- <div class="mb-3">
                     <label for="discounts" class="h6">Chương trình khuyến mại</label>
                     <select name="discount" id="discount" class="form-select">
                         <option value="">Không có</option>
@@ -86,7 +86,7 @@
                             <option value="{{ $disitem->id }}" {{ $product->discount_id == $disitem->id ? 'selected':'' }}>{{ $disitem->name }}</option>
                         @endforeach
                     </select>
-                </div>
+                </div> --}}
 
                 <h6>Đặt trạng thái</h6>
                 <div class="row">

--- a/resources/views/admin/product/index.blade.php
+++ b/resources/views/admin/product/index.blade.php
@@ -40,7 +40,7 @@
                             <td>{{ $orderCount++ }}</td>
                             <td>{{ $proditem->name }}</td>
                             <td>{{ $proditem->category->name }}</td>
-                            <td>{{ number_format($proditem->price) }} đ</td>
+                            <td>{{ number_format($proditem->price, 0, ".", ".") }} đ</td>
                             <td>{{ $proditem->stock_quantity }}</td>
                             <td>{{ $proditem->status == '1' ? 'Ẩn':'Hiện' }}</td>
                             <td>

--- a/resources/views/admin/product/index.blade.php
+++ b/resources/views/admin/product/index.blade.php
@@ -40,7 +40,7 @@
                             <td>{{ $orderCount++ }}</td>
                             <td>{{ $proditem->name }}</td>
                             <td>{{ $proditem->category->name }}</td>
-                            <td>{{ number_format($proditem->price, 0, ".", ".") }} đ</td>
+                            <td>{{ number_format($proditem->price, 0, ",", ".") }} đ</td>
                             <td>{{ $proditem->stock_quantity }}</td>
                             <td>{{ $proditem->status == '1' ? 'Ẩn':'Hiện' }}</td>
                             <td>

--- a/resources/views/admin/product/index.blade.php
+++ b/resources/views/admin/product/index.blade.php
@@ -26,24 +26,22 @@
                     <tr>
                         <th>STT</th>
                         <th>Tên sản phẩm</th>
-                        <th>Ảnh đại diện</th>
                         <th>Danh mục</th>
                         <th>Giá bán</th>
+                        <th>Số lượng còn lại</th>
                         <th>Trạng thái</th>
-                        <th>Tác vụ</th>
+                        <th style="width:18%">Tác vụ</th>
                     </tr>
                 </thead>
 
                 <tbody>
                     @foreach ($product as $proditem)
                         <tr>
-                            <td>{{ $proditem->id }}</td>
+                            <td>{{ $orderCount++ }}</td>
                             <td>{{ $proditem->name }}</td>
-                            <td> 
-                                <img src="{{ asset('images/products/thumbnail/' . $proditem->thumbnail) }}" width="70px" height="70px" alt="Thumbnail">
-                            </td>
                             <td>{{ $proditem->category->name }}</td>
-                            <td>{{ $proditem->price }} VNĐ</td>
+                            <td>{{ number_format($proditem->price) }} đ</td>
+                            <td>{{ $proditem->stock_quantity }}</td>
                             <td>{{ $proditem->status == '1' ? 'Ẩn':'Hiện' }}</td>
                             <td>
                                 <div class="row">

--- a/resources/views/admin/product/show.blade.php
+++ b/resources/views/admin/product/show.blade.php
@@ -76,7 +76,7 @@
             <div class="row">
                 <div class="mb-3 col-md-6">
                     <label class="h6">Trạng thái:</label>
-                    <p> {{ $product->status == '1' ? 'Khóa':'Mở' }} </p>
+                    <p> {{ $product->status == '1' ? 'Ẩn':'Hiện' }} </p>
                 </div>
 
                 <div class="mb-3 col-md-6">

--- a/resources/views/admin/user/index.blade.php
+++ b/resources/views/admin/user/index.blade.php
@@ -21,7 +21,7 @@
             <table class="table table-bordered" id="myTable">
                 <thead>
                     <tr>
-                        <th>ID</th>
+                        <th>STT</th>
                         <th>Tên người dùng</th>
                         <th>Email</th>
                         <th>Số điện thoại</th>
@@ -34,7 +34,7 @@
                 <tbody>
                     @foreach ($user as $useritem)
                         <tr>
-                            <td>{{ $useritem->id }}</td>
+                            <td>{{ $orderCount++ }}</td>
                             <td>{{ $useritem->name }}</td>
                             <td>{{ $useritem->email }}</td>
                             <td>{{ $useritem->phone_number }}</td>

--- a/resources/views/layouts/inc/admin/admin-navbar.blade.php
+++ b/resources/views/layouts/inc/admin/admin-navbar.blade.php
@@ -18,9 +18,9 @@
                 {{ Auth::user()->name }}
             </a>
             <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-                <li><a class="dropdown-item" href="#!">Cài đặt</a></li>
+                {{-- <li><a class="dropdown-item" href="#!">Cài đặt</a></li>
                 <li><a class="dropdown-item" href="#!">Activity Log</a></li>
-                <li><hr class="dropdown-divider" /></li>
+                <li><hr class="dropdown-divider" /></li> --}}
                 <li>
                     <a class="dropdown-item" href="{{ route('logout') }}"
                     onclick="event.preventDefault();

--- a/resources/views/layouts/inc/admin/admin-sidebar.blade.php
+++ b/resources/views/layouts/inc/admin/admin-sidebar.blade.php
@@ -2,7 +2,7 @@
     <nav class="sb-sidenav accordion sb-sidenav-dark" id="sidenavAccordion">
         <div class="sb-sidenav-menu">
             <div class="nav">
-                <div class="sb-sidenav-menu-heading">Core</div>
+                <div class="sb-sidenav-menu-heading">Trang chủ</div>
                 <a class="nav-link {{ Request::is('admin/dashboard') ? 'active':'' }}" href="{{ url('admin/dashboard') }}">
                     <div class="sb-nav-link-icon"><i class="fas fa-tachometer-alt"></i></div>
                     Dashboard
@@ -32,7 +32,7 @@
                 || Request::is('admin/categories') 
                 ? 'collapse active':'collapsed' }}" href="#" data-bs-toggle="collapse" data-bs-target="#collapsePagesManageProducts" aria-expanded="false" aria-controls="collapsePagesManageProducts">
                     <div class="sb-nav-link-icon"><i class="fas fa-columns"></i></div>
-                    Quản trị danh mục
+                    Quản trị ngành hàng
                     <div class="sb-sidenav-collapse-arrow"><i class="fas fa-angle-down"></i></div>
                 </a>
                 <div class="collapse 
@@ -101,7 +101,7 @@
                     </nav>
                 </div>
 
-                <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapsePages" aria-expanded="false" aria-controls="collapsePages">
+                {{-- <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapsePages" aria-expanded="false" aria-controls="collapsePages">
                     <div class="sb-nav-link-icon"><i class="fas fa-book-open"></i></div>
                     Pages
                     <div class="sb-sidenav-collapse-arrow"><i class="fas fa-angle-down"></i></div>
@@ -131,9 +131,9 @@
                             </nav>
                         </div>
                     </nav>
-                </div>
+                </div> --}}
                 
-                <div class="sb-sidenav-menu-heading">Addons</div>
+                {{-- <div class="sb-sidenav-menu-heading">Addons</div>
                 <a class="nav-link" href="charts.html">
                     <div class="sb-nav-link-icon"><i class="fas fa-chart-area"></i></div>
                     Charts
@@ -141,7 +141,7 @@
                 <a class="nav-link" href="tables.html">
                     <div class="sb-nav-link-icon"><i class="fas fa-table"></i></div>
                     Tables
-                </a>
+                </a> --}}
             </div>
         </div>
         <div class="sb-sidenav-footer">


### PR DESCRIPTION
Em đã điều chỉnh lại các trang admin theo góp ý của các anh/chị ạ. Những phần em đã làm:
- Trang product_index: Đưa trường số lượng ra bảng, format lại số giá tiền bằng hàm number_format().
- Trang order: format lại các giá trị số tiền cũng bằng hàm number_format().
- Các bảng index brands, products, categories, users: Thay đổi cột stt hiển thị bằng biến $orderCount thay vì giá trị id.
- Điều chỉnh phần phân quyền: Em đã thêm một user_type mới là Master Admin với giá trị user_type = 2. Khi hiện danh sách người dùng ở trang user_index sẽ chỉ lấy những user có type = 1 (admin) hoặc = 0 (user).
- Comment một số chức năng không dùng tới.

Những phần em chưa làm được/đang suy nghĩ, tìm hiểu:
- Điều chỉnh chức năng upload ảnh
- Sửa các hàm xóa để không bị quay về trang đầu phần phân trang