### PR TITLE
Task adjust frontend pages

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -75,7 +75,7 @@ class ProductController extends Controller
         $product->images = implode("|", $images);
         $product->price = $data['price'];
         $product->stock_quantity = $data['stock_quantity'];
-        $product->discount_id = $data['discount'];
+        // $product->discount_id = $data['discount'];
         $product->status = $request->status == true ? '1':'0';
         $product->trending = $request->trending == true ? '1':'0';
         $product->created_by = Auth::user()->id;
@@ -163,7 +163,7 @@ class ProductController extends Controller
         }
         $product->price = $data['price'];
         $product->stock_quantity = $data['stock_quantity'];
-        $product->discount_id = $data['discount'];
+        // $product->discount_id = $data['discount'];
         $product->status = $request->status == true ? '1':'0';
         $product->trending = $request->trending == true ? '1':'0';
         $product->created_by = Auth::user()->id;

--- a/app/Http/Controllers/Frontend/FrontendController.php
+++ b/app/Http/Controllers/Frontend/FrontendController.php
@@ -26,7 +26,8 @@ class FrontendController extends Controller
         } 
         else 
         {
-            return redirect()->back();
+            $searchProducts = Product::paginate(10);
+            return view('frontend.pages.search', compact('searchProducts'));
         }
     }
 

--- a/app/Http/Livewire/Frontend/Checkout/CheckoutShow.php
+++ b/app/Http/Livewire/Frontend/Checkout/CheckoutShow.php
@@ -77,7 +77,7 @@ class CheckoutShow extends Component
 
     public function totalAmount()
     {
-        $this->totalAmount = Cart::subtotal();
+        $this->totalAmount = Cart::subtotal(0, ',', '.');
         return $this->totalAmount;
     }
 

--- a/resources/views/admin/order/edit.blade.php
+++ b/resources/views/admin/order/edit.blade.php
@@ -60,9 +60,9 @@
                                     <img src="{{ asset('images/products/thumbnail/' . $orderitem->product->thumbnail) }}" style="width: 70px; height: 70px" alt="">
                                 </td>
                                 <td>{{ $orderitem->product->name }}</td>
-                                <td>{{ number_format($orderitem->price, 0, ".", ".") }} đ</td>
+                                <td>{{ number_format($orderitem->price, 0, ",", ".") }} đ</td>
                                 <td>{{ $orderitem->quantity }}</td>
-                                <td class="fw-bold">{{ number_format($orderitem->quantity * $orderitem->price, 0, ".", ".") }} đ</td>
+                                <td class="fw-bold">{{ number_format($orderitem->quantity * $orderitem->price, 0, ",", ".") }} đ</td>
                                 @php
                                     $totalPrice += $orderitem->price * $orderitem->quantity;
                                 @endphp
@@ -70,7 +70,7 @@
                             @endforeach
                             <tr>
                                 <td colspan="5" class="fw-bold">Tổng tiền đơn hàng:</td>
-                                <td colspan="1" class="fw-bold">{{ number_format($totalPrice, 0, ".", ".") }} đ</td>
+                                <td colspan="1" class="fw-bold">{{ number_format($totalPrice, 0, ",", ".") }} đ</td>
                             </tr>
                         </tbody>
                     </table>

--- a/resources/views/frontend/index.blade.php
+++ b/resources/views/frontend/index.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'LaraKon Home')
 
 @section('content')
-<div class="py-5 bg-white">
+{{-- <div class="py-5 bg-white">
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-md-8 text-center">
@@ -15,7 +15,7 @@
             </div>
         </div>
     </div>
-</div>
+</div> --}}
 
 <div class="py-5">
     <div class="container">

--- a/resources/views/frontend/index.blade.php
+++ b/resources/views/frontend/index.blade.php
@@ -34,7 +34,6 @@
                     <div class="item">
                         <div class="product-card">
                             <div class="product-card-img">
-                                <label class="stock bg-danger">Mới</label>
                                 <img src="{{ asset('images/products/thumbnail/' . $proditem->thumbnail) }}" alt="thumbnail">
                             </div>
         
@@ -46,7 +45,7 @@
                                     </a>
                                 </h5>
                                 <div>
-                                    <span class="selling-price">{{ $proditem->price }} VNĐ</span>
+                                    <span class="selling-price">{{ number_format($proditem->price, 0, ',', '.') }} đ</span>
                                     {{-- <span class="original-price">$799</span> --}}
                                 </div>
                                 <div class="mt-2">
@@ -101,7 +100,7 @@
                                     </a>
                                 </h5>
                                 <div>
-                                    <span class="selling-price">{{ $proditem->price }} VNĐ</span>
+                                    <span class="selling-price">{{ number_format($proditem->price, 0, ',', '.') }} đ</span>
                                     {{-- <span class="original-price">$799</span> --}}
                                 </div>
                                 <div class="mt-2">

--- a/resources/views/frontend/orders/show.blade.php
+++ b/resources/views/frontend/orders/show.blade.php
@@ -64,9 +64,9 @@
                                         <img src="{{ asset('images/products/thumbnail/' . $orderitem->product->thumbnail) }}" style="width: 70px; height: 70px" alt="">
                                     </td>
                                     <td>{{ $orderitem->product->name }}</td>
-                                    <td>{{ $orderitem->price }} VNĐ</td>
+                                    <td>{{ number_format($orderitem->price, 0, ",", ".") }} đ</td>
                                     <td>{{ $orderitem->quantity }}</td>
-                                    <td class="fw-bold">{{ $orderitem->quantity * $orderitem->price }} VNĐ</td>
+                                    <td class="fw-bold">{{ number_format($orderitem->quantity * $orderitem->price, 0, ",", ".") }} đ</td>
                                     @php
                                         $totalPrice += $orderitem->price * $orderitem->quantity;
                                     @endphp
@@ -74,7 +74,7 @@
                                 @endforeach
                                 <tr>
                                     <td colspan="5" class="fw-bold">Tổng tiền đơn hàng:</td>
-                                    <td colspan="1" class="fw-bold">{{ $totalPrice }} VNĐ</td>
+                                    <td colspan="1" class="fw-bold">{{ number_format($totalPrice, 0, ",", ".") }} đ</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/resources/views/frontend/pages/new-arrival.blade.php
+++ b/resources/views/frontend/pages/new-arrival.blade.php
@@ -27,7 +27,7 @@
                                 </a>
                             </h5>
                             <div>
-                                <span class="selling-price">{{ $proditem->price }} VNĐ</span>
+                                <span class="selling-price">{{ number_format($proditem->price, 0, ',', '.') }} đ</span>
                                 {{-- <span class="original-price">$799</span> --}}
                             </div>
                             <div class="mt-2">

--- a/resources/views/frontend/pages/search.blade.php
+++ b/resources/views/frontend/pages/search.blade.php
@@ -30,13 +30,10 @@
                                         </a>
                                     </h5>
                                     <div>
-                                        <span class="selling-price">{{ $proditem->price }} VNĐ</span>
+                                        <span class="selling-price">{{ number_format($proditem->price, 0, ',', '.') }} đ</span>
                                         {{-- <span class="original-price">$799</span> --}}
                                     </div>
                                     
-                                    <p style="height: 45px; overflow: hidden">
-                                        <b>Mô tả: </b> {!! $proditem->description !!}
-                                    </p>
                                     <a href="{{ url('/collections/' . $proditem->category->slug . '/' . $proditem->slug ) }}" class="btn btn1">
                                         <i class="fa fa-shopping-cart"></i>
                                         Mua ngay

--- a/resources/views/frontend/pages/trending.blade.php
+++ b/resources/views/frontend/pages/trending.blade.php
@@ -27,7 +27,7 @@
                                 </a>
                             </h5>
                             <div>
-                                <span class="selling-price">{{ $proditem->price }} VNĐ</span>
+                                <span class="selling-price">{{ number_format($proditem->price, 0, ',', '.') }} đ</span>
                                 {{-- <span class="original-price">$799</span> --}}
                             </div>
                             <div class="mt-2">

--- a/resources/views/layouts/inc/frontend/frontend-footer.blade.php
+++ b/resources/views/layouts/inc/frontend/frontend-footer.blade.php
@@ -2,14 +2,7 @@
     <div class="footer-area">
         <div class="container">
             <div class="row">
-                <div class="col-md-3">
-                    <h4 class="footer-heading">LaraKon</h4>
-                    <div class="footer-underline"></div>
-                    <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet risus sagittis, eleifend urna in, scelerisque dui. Nunc dignissim leo at magna egestas congue.
-                    </p>
-                </div>
-                <div class="col-md-3">
+                <div class="col-md-4">
                     <h4 class="footer-heading">Đường dẫn</h4>
                     <div class="footer-underline"></div>
                     <div class="mb-2"><a href="{{ url('/') }}" class="text-white">Trang chủ</a></div>
@@ -18,7 +11,7 @@
                     <div class="mb-2"><a href="{{ url('blog') }}" class="text-white">Bài viết</a></div>
                     <div class="mb-2"><a href="#" class="text-white">Bản đồ</a></div>
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-4">
                     <h4 class="footer-heading">Mua hàng ngay</h4>
                     <div class="footer-underline"></div>
                     <div class="mb-2"><a href="{{ url('collections') }}" class="text-white">Danh mục</a></div>
@@ -26,12 +19,12 @@
                     <div class="mb-2"><a href="" class="text-white">Hàng mới về</a></div>
                     <div class="mb-2"><a href="{{ url('cart') }}" class="text-white">Giỏ hàng</a></div>
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-4">
                     <h4 class="footer-heading">Liên hệ chúng tôi</h4>
                     <div class="footer-underline"></div>
                     <div class="mb-2">
                         <p>
-                            <i class="fa fa-map-marker"></i> 1240 Diệu Hạnh Rue, Hà Nội, 11414
+                            <i class="fa fa-map-marker"></i> 124 Diệu Hạnh, Hà Nội
                         </p>
                     </div>
                     <div class="mb-2">

--- a/resources/views/layouts/inc/frontend/frontend-navbar.blade.php
+++ b/resources/views/layouts/inc/frontend/frontend-navbar.blade.php
@@ -3,7 +3,9 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col-md-2 my-auto d-none d-sm-none d-md-block d-lg-block">
-                    <img src="{{ asset('images/LaraKonLogo.png') }}" width="123px" height="60px" alt="logo">
+                    <a href="{{ url('/') }}">
+                        <img src="{{ asset('images/LaraKonLogo.png') }}" width="123px" height="60px" alt="logo">
+                    </a>
                 </div>
                 <div class="col-md-5 my-auto">
                     <form action="{{ url('search') }}" method="GET" role="search">
@@ -78,9 +80,6 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ url('/') }}">Trang chủ</a>
-                    </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url('/collections') }}">Tất cả danh mục</a>
                     </li>

--- a/resources/views/livewire/frontend/cart/cart-show.blade.php
+++ b/resources/views/livewire/frontend/cart/cart-show.blade.php
@@ -43,7 +43,7 @@
                                     </a>
                                 </div>
                                 <div class="col-md-2 my-auto">
-                                    <label class="price"> {{ $cartitem->model->price }} VNĐ </label>
+                                    <label class="price">{{ number_format($cartitem->model->price, 0, ',', '.') }} đ</label>
                                 </div>
                                 <div class="col-md-2 col-7 my-auto">
                                     <div class="quantity">
@@ -61,7 +61,7 @@
                                     </div>
                                 </div>
                                 <div class="col-md-2 my-auto">
-                                    <label class="price"> {{ $cartitem->subtotal }} VNĐ </label>
+                                    <label class="price">{{ number_format($cartitem->subtotal, 0, ',', '.') }} đ</label>
                                 </div>
                                 <div class="col-md-2 col-5 my-auto">
                                     <div class="remove">
@@ -101,7 +101,8 @@
                     <h5>
                         Tổng tiền:
                         <span class="float-end">
-                            {{ Cart::subtotal() }} VNĐ
+                            
+                            {{ Cart::subtotal(0, ',', '.') }} đ
                         </span>
                     </h5>
                     <hr>

--- a/resources/views/livewire/frontend/checkout/checkout-show.blade.php
+++ b/resources/views/livewire/frontend/checkout/checkout-show.blade.php
@@ -40,13 +40,13 @@
                                     </a>
                                 </div>
                                 <div class="col-md-2 my-auto">
-                                    <label class="price"> {{ $cartitem->model->price }} VNĐ </label>
+                                    <label class="price"> {{ number_format($cartitem->model->price, 0, ',', '.') }} đ</label>
                                 </div>
                                 <div class="col-md-2 my-auto">
                                     <label class="price"> {{ $cartitem->qty }} </span>
                                 </div>
                                 <div class="col-md-2 my-auto">
-                                    <label class="price"> {{ $cartitem->subtotal }} VNĐ </label>
+                                    <label class="price"> {{ number_format($cartitem->subtotal, 0, ',', '.') }} đ</label>
                                 </div>
                             </div>
                         </div>
@@ -58,7 +58,7 @@
                     <div class="shadow bg-white p-3">
                         <h4 class="text-primary">
                             Tổng tiền đơn hàng:
-                            <span class="float-end">{{ $this->totalAmount }} VNĐ</span>
+                            <span class="float-end">{{ $this->totalAmount }} đ</span>
                         </h4>
                         <hr>
                         <small>* Hàng sẽ được giao đến trong 3-5 ngày.</small>

--- a/resources/views/livewire/frontend/product/index.blade.php
+++ b/resources/views/livewire/frontend/product/index.blade.php
@@ -37,7 +37,7 @@
                                 </a>
                             </h5>
                             <div>
-                                <span class="selling-price">{{ $proditem->price }} VNĐ</span>
+                                <span class="selling-price">{{ number_format($proditem->price, 0, ',', '.') }} đ</span>
                                 {{-- <span class="original-price">$799</span> --}}
                             </div>
                             <div class="mt-2">

--- a/resources/views/livewire/frontend/product/show.blade.php
+++ b/resources/views/livewire/frontend/product/show.blade.php
@@ -6,7 +6,16 @@
                     {{ session('message') }}
                 </div>
             @endif
+
             <div class="row">
+                <div class="product-view">
+                    <p class="product-path">
+                        <a href="{{ url('/') }}">Trang chủ</a>/ 
+                        <a href="{{ url('collections/'.$category->slug) }}">{{ $product->category->name }}</a>/ 
+                        {{ $product->name }}
+                    </p>
+                </div>
+
                 <div class="col-md-5 mt-3">
                     <div class="bg-white border" wire:ignore>
                         @if ($product->images)
@@ -44,15 +53,11 @@
                             {{ $product->name }}
                         </h4>
                         <hr>
-                        
-                        <p class="product-path">
-                            Trang chủ / {{ $product->category->name }} / {{ $product->name }}
-                        </p>
 
                         <p class="product-path">Thương hiệu: {{ $product->brand->name }}</p>
                         
                         <div>
-                            <span class="selling-price">{{ $product->price }} VNĐ</span>
+                            <span class="selling-price">{{ number_format($product->price, 0, ',', '.') }} đ</span>
                             {{-- <span class="original-price">$499</span> --}}
                         </div>
                         

--- a/resources/views/livewire/frontend/wishlist/wishlist-show.blade.php
+++ b/resources/views/livewire/frontend/wishlist/wishlist-show.blade.php
@@ -34,7 +34,7 @@
                                         </a>
                                     </div>
                                     <div class="col-md-2 my-auto">
-                                        <label class="price"> {{$wlitem->product->price}} VNĐ </label>
+                                        <label class="price"> {{ number_format($wlitem->product->price, 0, ',', '.') }} đ</label>
                                     </div>
                                     
                                     <div class="col-md-4 col-12 my-auto">


### PR DESCRIPTION
Đây e đã điều chỉnh và format lại một số phần trong các trang frontend:
- Format lại giá tiền ở toàn bộ các trang.
- Format phần breadcrumb ở trang product_detail thành link truy cập được.
- Bỏ phần mô tả ở thẻ kết quả tìm kiếm sản phẩm.
- Sửa logic phần tìm kiếm để trả về tất cả sản phẩm khi nhấp ô tìm kiếm trống.