### PR TITLE
Reworked product detail wishlist button function

### DIFF
--- a/app/Http/Livewire/Frontend/Product/Show.php
+++ b/app/Http/Livewire/Frontend/Product/Show.php
@@ -16,38 +16,37 @@ class Show extends Component
     {
         if(Auth::check())
         {
-            if (Wishlist::where('user_id', auth()->user()->id)->where('product_id', $productId)->exists()) 
-            {
-                $this->dispatchBrowserEvent('message', [
-                    'text' => 'Sản phẩm đã có trong mục ưa thích',
-                    'type' => 'warning',
-                    'status' => 409
-                ]);
-                return false;
-            } 
-            else 
-            {
-                Wishlist::create([
-                    'user_id' => auth()->user()->id,
-                    'product_id' => $productId
-                ]);
-                $this->emit('wishlistUpdated');
-                $this->dispatchBrowserEvent('message', [
-                    'text' => 'Đã thêm vào mục ưa thích',
-                    'type' => 'success',
-                    'status' => 200
-                ]);
-            }
+            Wishlist::create([
+                'user_id' => auth()->user()->id,
+                'product_id' => $productId
+            ]);
+            $this->emit('wishlistUpdated');
+            $this->dispatchBrowserEvent('message', [
+                'text' => 'Đã thêm vào mục ưa thích',
+                'type' => 'success',
+                'status' => 200
+            ]);
         }
         else
         {
             $this->dispatchBrowserEvent('message', [
                 'text' => 'Mời bạn vui lòng đăng nhập để tiếp tục',
-                'type' => 'info',
+                'type' => 'warning',
                 'status' => 401
             ]);
             return false;
         }
+    }
+
+    public function removeFromWishlist()
+    {
+        Wishlist::where('user_id', auth()->user()->id)->where('product_id', $this->product->id)->delete();
+        $this->emit('wishlistUpdated');
+        $this->dispatchBrowserEvent('message', [
+            'text' => 'Đã xóa sản phẩm khỏi mục ưa thích',
+            'type' => 'success',
+            'status' => 200
+        ]);
     }
 
     public function quantityDecrement()
@@ -92,9 +91,11 @@ class Show extends Component
 
     public function render()
     {
+        $wlitem = Wishlist::where('user_id', auth()?->user()?->id)->where('product_id', $this->product->id);
         return view('livewire.frontend.product.show', [
             'category' => $this->category,
-            'product' => $this->product
+            'product' => $this->product,
+            'wlitem' => $wlitem,
         ]);
     }
 }

--- a/resources/views/livewire/frontend/product/show.blade.php
+++ b/resources/views/livewire/frontend/product/show.blade.php
@@ -88,14 +88,19 @@
                             > 
                                 <i class="fa fa-shopping-cart"></i> Thêm vào giỏ hàng 
                             </button>
+                            @if ($wlitem->exists())
+                            <button type="button" wire:click="removeFromWishlist({{ $product->id }})" class="btn btn1">
+                                <span wire:target="removeFromWishlist">
+                                    <i class="fa fa-heart"></i> Bỏ ưa thích
+                                </span> 
+                            </button>
+                            @else
                             <button type="button" wire:click="addToWishlist({{ $product->id }})" class="btn btn1">
-                                <span wire:loading.remove wire:target="addToWishlist">
+                                <span wire:target="addToWishlist">
                                     <i class="fa fa-heart"></i> Ưa thích 
                                 </span> 
-                                <span wire:loading wire:target="addToWishlist">
-                                    Đang thêm...
-                                </span>
                             </button>
+                            @endif
                         </div>
                     </div>
                 </div>

--- a/resources/views/livewire/frontend/product/show.blade.php
+++ b/resources/views/livewire/frontend/product/show.blade.php
@@ -91,13 +91,13 @@
                             @if ($wlitem->exists())
                             <button type="button" wire:click="removeFromWishlist({{ $product->id }})" class="btn btn1">
                                 <span wire:target="removeFromWishlist">
-                                    <i class="fa fa-heart"></i> Bỏ ưa thích
+                                    <i class="bi bi-heart-fill"></i> Bỏ ưa thích
                                 </span> 
                             </button>
                             @else
                             <button type="button" wire:click="addToWishlist({{ $product->id }})" class="btn btn1">
                                 <span wire:target="addToWishlist">
-                                    <i class="fa fa-heart"></i> Ưa thích 
+                                    <i class="bi bi-heart"></i> Ưa thích 
                                 </span> 
                             </button>
                             @endif


### PR DESCRIPTION
Em đã sửa lại hoàn toàn chức năng cho nút ưa thích ở trang product_detail ạ.
Bây giờ nhấn ưa thích sẽ hiện thông báo là đã thêm vào danh sách, còn nút sẽ đổi thành "Bỏ ưa thích".
Khi nhấn "Bỏ ưa thích" thì sẽ hiện thông báo, xóa luôn sản phẩm trong mục ưa thích và đổi về "Ưa thích" ạ.